### PR TITLE
Convertir sitio a páginas de Github

### DIFF
--- a/.docker/jekyll.dockerfile
+++ b/.docker/jekyll.dockerfile
@@ -1,0 +1,32 @@
+FROM ruby:2.5
+
+RUN apt-get update \
+  && apt-get install -y \
+    git \
+    locales \
+    make \
+    nodejs
+
+
+RUN \
+  echo "en_US UTF-8" > /etc/locale.gen && \
+  locale-gen en-US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+
+RUN bundle install --gemfile=
+
+RUN apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+EXPOSE 4000
+
+ENTRYPOINT ["bundle", "exec"]
+
+CMD ["jekyll", "serve","--host=0.0.0.0"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 config.py
 *.pyc
+.sass-cache/
+Gemfile.lock
+_site/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+gem "jekyll", "3.8.5"
+gem "github-pages", group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ de que le falte información desde su integración, favor de alimentar la inform
 plantillas.
 
 ### Ver a continuación
-- [Servidor de Pruebas](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Obtención de juego de llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
-- [Ruta de Recursos](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Comandos HTTP](https://github.com/hvalles/marketsync/blob/master/links/http.md)
-- [Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
-- [Mejores Prácticas](https://github.com/hvalles/marketsync/blob/master/links/best.md)
+- [Servidor de Pruebas](/links/server.html)
+- [Obtención de juego de llaves](/links/keys.html)
+- [Ruta de Recursos](/links/url.html)
+- [Comandos HTTP](/links/http.html)
+- [Controladores](/links/controller.html)
+- [Mejores Prácticas](/links/best.html)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,21 @@
+---
+baseurl: ""
+
+title: MarketSync
+description: Marketsync Documentación de API
+logo: https://images.squarespace-cdn.com/content/570d910f4d088ed2c69df6bf/1568258211068-QRXDP9NCJED3F5BYTU9U/MS-08R.png?format=1500w&content-type=image%2Fpng
+show_downloads: false
+
+#repository: your/repo
+theme: jekyll-theme-minimal
+
+gems:
+- jekyll-github-metadata
+- jekyll-redirect-from
+- jekyll-sitemap
+- jemoji
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - docker-compose.yml

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 baseurl: ""
 
 title: MarketSync
-description: Marketsync Documentación de API
+description: "" # Marketsync Documentación de API
 logo: https://images.squarespace-cdn.com/content/570d910f4d088ed2c69df6bf/1568258211068-QRXDP9NCJED3F5BYTU9U/MS-08R.png?format=1500w&content-type=image%2Fpng
 show_downloads: false
 
@@ -10,10 +10,10 @@ show_downloads: false
 theme: jekyll-theme-minimal
 
 gems:
-- jekyll-github-metadata
-- jekyll-redirect-from
-- jekyll-sitemap
-- jemoji
+  - jekyll-github-metadata
+  - jekyll-redirect-from
+  - jekyll-sitemap
+  - jemoji
 
 exclude:
   - Gemfile

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+</head>
+<body>
+<div class="wrapper">
+    <header>
+        <h1><a href="{{ "/" | absolute_url }}"><img src="{{site.logo | relative_url}}" alt="{{ site.title | default: site.github.repository_name }}" /></a></h1>
+
+        <p>{{ site.description | default: site.github.project_tagline }}</p>
+
+        {% if site.github.is_user_page %}
+        <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
+        {% endif %}
+
+        {% if site.show_downloads %}
+        <ul class="downloads">
+            <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
+            <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
+            <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+        </ul>
+        {% endif %}
+    </header>
+    <section>
+
+        {{ content }}
+
+    </section>
+    <footer>
+        {% if site.github.is_project_page %}
+        <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ site.github.repository_nwo }}</small></a></p>
+        {% endif %}
+    </footer>
+</div>
+<script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+{% if site.google_analytics %}
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', '{{ site.google_analytics }}', 'auto');
+    ga('send', 'pageview');
+</script>
+{% endif %}
+</body>
+</html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,19 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+header {
+  width: unset;
+  float: unset;
+  position: unset;
+}
+section {
+  width: unset;
+  float: unset;
+}
+footer {
+  width: unset;
+  float: unset;
+  position: unset;
+}

--- a/controllers/categorias.md
+++ b/controllers/categorias.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Categorias
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza como catálogo general, lo que impica que báscamente su uso será de lectura.
 
@@ -133,7 +133,7 @@ Devuelve un conjunto de atributos válidos de acuerdo a cada categoría en donde
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/colores.md
+++ b/controllers/colores.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Colores
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza como catálogo general, lo que impica que báscamente su uso será de lectura.
 
@@ -17,7 +17,7 @@ URL:
 http://sandbox.marketsync.mx/api/colores?timestamp=2019-12-12T10%3A52%3A34.193000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=1a7cb61e0167084310dc5a26013c0531445e5275be283aa002a13f18f1890d01
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -48,7 +48,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/fulfillment.md
+++ b/controllers/fulfillment.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Fulfillment
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para visualizar El Stock de los productos estableciudos como Fulfillment, es decir que el
 
@@ -17,7 +17,7 @@ URL:
 http://sandbox.marketsync.mx/api/fulfillment?timestamp=2019-12-12T10%3A52%3A33.195000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=e48273e6a215eb5afda5ea52919e698fadf90691df5a1090f90f578e279dae32
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -60,7 +60,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/guias.md
+++ b/controllers/guias.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Guías
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza como llamada posterior a la descarga del pedido, para recuperar información acerca de las guías. La guías, "NO" se generan de forma automática, son alimentada a través del sitio web de la aplicación que genera el pedido o a petición manual del usuario en el portal de MarketSync, dependiendo de
 la plataforma a utilizar y lo que su API permita.
@@ -30,7 +30,7 @@ http://sandbox.marketsync.mx/api/guias?timestamp=2019-12-12T10%3A52%3A34.690000&
 
 
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -61,7 +61,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/markets.md
+++ b/controllers/markets.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Markets
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para visualizar los MarketPlaces vigentes, como para actualizar su participación en los mismos.
 
@@ -17,7 +17,7 @@ URL:
 http://sandbox.marketsync.mx/api/markets?timestamp=2019-12-12T10%3A52%3A33.195000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=e48273e6a215eb5afda5ea52919e698fadf90691df5a1090f90f578e279dae32
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -88,7 +88,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/paises.md
+++ b/controllers/paises.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Paises
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza como catálogo general, lo que impica que báscamente su uso será de lectura.
 
@@ -17,7 +17,7 @@ URL:
 http://sandbox.marketsync.mx/api/paises?timestamp=2019-12-12T10%3A52%3A34.690000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=5e111544f6d8519780daacf7804b25a9f4d4acb892e7e272b9b4ad1461fc507c
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -57,7 +57,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/pedidos.md
+++ b/controllers/pedidos.md
@@ -173,6 +173,7 @@ Se utiliza para actualizar el estatus del pedido y agregar comentarios acerca de
 [Ver ejemplo en python](../examples/python/pedidos.py)
 
 Listado de  estatus por MarketPlace
+
 |id	|market_id|market|estatus|
 |---|---------|------|-------|
 | 1	|1|	Claro|	Pendiente|

--- a/controllers/pedidos.md
+++ b/controllers/pedidos.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Pedidos
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza medio de procesamiento para los pedidos, obteniendo la informacion de los mismos, así coo permitiendo ingresar nuevos de tus ventas en línea.
 
@@ -15,7 +15,7 @@ URL:
 http://sandbox.marketsync.mx/api/pedidos?after=2019-11-15T00%3A00&before=2019-11-16T00%3A00&limit=2&offset=5&timestamp=2019-12-12T10%3A52%3A31.231000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=8facfb793eacc4c224ffdea280c0cf928ffc8948b31d5893de02d124fa3fc579
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -205,6 +205,6 @@ Listado de  estatus por MarketPlace
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)

--- a/controllers/precios.md
+++ b/controllers/precios.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Precios
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza como catálogo general, lo que impica que báscamente su uso será de lectura.
 
@@ -17,7 +17,7 @@ URL:
 http://sandbox.marketsync.mx/api/precios?limit=5&timestamp=2019-12-12T10%3A52%3A35.181000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=7de055d3dd9c96d191fd2e44bf7c6b37956cba52bb05a7bdc8b44189845e0b25
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -104,7 +104,7 @@ URL:
 http://sandbox.marketsync.mx/api/precios?limit=5&timestamp=2019-12-12T10%3A52%3A35.181000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=7de055d3dd9c96d191fd2e44bf7c6b37956cba52bb05a7bdc8b44189845e0b25
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -157,7 +157,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/productos.md
+++ b/controllers/productos.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Productos
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para dar mantenimiento al catálogo de productos, contiene todas las acciones http.
 
@@ -19,7 +19,7 @@ URL:
 http://sandbox.marketsync.mx/api/productos?limit=1&timestamp=2019-12-12T15%3A47%3A37.234000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=27f8be294fc5599bc0aea10295d7d541a6a708251ccfebd1e4b74279eaff90a1
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -311,7 +311,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/publicar.md
+++ b/controllers/publicar.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Publicaciones
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para emitir acciones por producto y MarketPlace, que nos brindan la oportunidad para Publicar, Suspender, Fulfillment o Agotar un producto en un MarkePlace en particular.
 
@@ -32,10 +32,10 @@ URL:
 http://sandbox.marketsync.mx/api/productos/publicar?timestamp=2019-12-12T10%3A52%3A35.699000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=12b1964acc697a4b4a8c80cb3ab0db253c48dc52d1db4bee6014191fe4c28c86
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 
-[Vea la implementación aqui](https://github.com/hvalles/marketsync/blob/master/examples/python/publicar.py)
+[Vea la implementación aqui](/examples/python/publicar.py)
 
 
 Respuesta:
@@ -65,7 +65,7 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)
 

--- a/controllers/stock.md
+++ b/controllers/stock.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Stock
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para actualizar el Stock de las variaciones, así como para actualizar la fecha de corte de la actualización.
 
@@ -20,7 +20,7 @@ URL:
 http://sandbox.marketsync.mx/api/stock?ids=162700&timestamp=2019-12-12T10%3A52%3A36.686000&token=r559f7ab1cr3f97c7cc64b7fa43r54af&version=1.0&signature=54a98aea2667c308ef086195b6d2c9d0ea71efa292071e6399e91bddd0b0144c
 ```
 
-[:link: Puede ver la composición del URL en el siguiente enlace.](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[:link: Puede ver la composición del URL en el siguiente enlace.](/links/url.html)
 
 Respuesta:
 ```javascript
@@ -136,6 +136,6 @@ Respuesta:
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)

--- a/controllers/variacion.md
+++ b/controllers/variacion.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Controlador de Variación
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 El controlador se utiliza para agregar o actualizar las variaciones de producto.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  jekyll:
+    build:
+      context: .
+      dockerfile: .docker/jekyll.dockerfile
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: "jekyll serve --host=0.0.0.0 --force_polling"

--- a/links/best.md
+++ b/links/best.md
@@ -1,8 +1,8 @@
 # Marketsync Documentación de API 
 ### Mejores Prácticas
 
-[Inicio](https://github.com/hvalles/marketsync)  
-[Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+[Inicio](/)  
+[Controladores](/links/controller.html)
 
 
 A continuación se detallan algunas bases y puntos e vista que le pueden permitir utilizar esta guía de forma adecuada y productiva.
@@ -40,6 +40,6 @@ A continuación se detallan algunas bases y puntos e vista que le pueden permiti
 
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)

--- a/links/controller.md
+++ b/links/controller.md
@@ -1,7 +1,7 @@
 # Marketsync Documentación de API 
 ### Seccion de Controladores
 
-[Inicio](https://github.com/hvalles/marketsync)
+[Inicio](/)
 
 Los controladores son las rutas que permiten el acceso al consumo de la API y/o lectura/escritura de cada modelo correspondiente.
 
@@ -21,6 +21,6 @@ Los controladores son las rutas que permiten el acceso al consumo de la API y/o 
 12. [Fulfillment](../controllers/fulfillment.md)
 #### También le puede interesar:
 
-- [Servidor](https://github.com/hvalles/marketsync/blob/master/links/server.md)
-- [Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
-- [Conjunto de Llaves](https://github.com/hvalles/marketsync/blob/master/links/keys.md)
+- [Servidor](/links/server.html)
+- [Ruta de Recurso](/links/url.html)
+- [Conjunto de Llaves](/links/keys.html)

--- a/links/http.md
+++ b/links/http.md
@@ -1,7 +1,7 @@
 # Marketsync Documentación de API 
 ### Seccion de comandos http
 
-[Inicio](https://github.com/hvalles/marketsync)
+[Inicio](/)
 
 ### Los comandos http utilizados en el consumo del API se describen a continuación
 
@@ -15,7 +15,7 @@
 ### Las APIs se encuentran divididas en secciones 
 De acuerdo al controlador de cada modelo y se limitan solamente a la funcionalidad expuesta por el diseño, es decir no todos los comandos aplican por cada controlador, usualmente los catálogos generales solamente podrás consultarlos.
 
-[Ver Ruta de Recurso](https://github.com/hvalles/marketsync/blob/master/links/url.md)
+[Ver Ruta de Recurso](/links/url.html)
 
 #### Lista de comandos aplicables a los controladores
 

--- a/links/keys.md
+++ b/links/keys.md
@@ -1,7 +1,7 @@
 # Marketsync Documentación de API 
 ### Seccion del conjunto de llaves
 
-[Inicio](https://github.com/hvalles/marketsync)
+[Inicio](/)
 
 ### Descripción de las llaves
 
@@ -97,4 +97,4 @@ $url = $SERVER . 'controller?' . $concatenated . '&signature=' . $sign;
 
 > :information_source: Importante
 > El texto controller de las urls expuestas en las llamadas de arriba, debe de ser cambiado por el controlador deseado. ver la sección de controladores para más información.
-- [Controladores](https://github.com/hvalles/marketsync/blob/master/links/controller.md)
+- [Controladores](/links/controller.html)

--- a/links/server.md
+++ b/links/server.md
@@ -1,7 +1,7 @@
 # Marketsync Documentación de API 
 ### Seccion de Servidor 
 
-[Inicio](https://github.com/hvalles/marketsync)
+[Inicio](/)
 
 ### Direccion del Servidor
 

--- a/links/url.md
+++ b/links/url.md
@@ -1,7 +1,7 @@
 # Marketsync Documentación de API 
 ### Seccion de URL 
 
-[Inicio](https://github.com/hvalles/marketsync)
+[Inicio](/)
 
 ### Formacion del URL para el consumo de recursos
 


### PR DESCRIPTION
Hi, Google Translate does not work with the Github project pages, probably because of the mixed-language content.. So I added a theme and made the project compatible with [Github Pages](https://pages.github.com/) so I could translate it more easily.

Screenshot:

![image](https://user-images.githubusercontent.com/38738/117511510-d4159100-af5b-11eb-9123-2ef33df9e9ff.png)


Steps:
1. Merge this Pull Request
2. Go to Github project settings, enable Pages
3. Site will be https://hvalles.github.io/marketsync
4. Optionally add a [custom CNAME](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site)

Also included is a `docker-compose.yml` file so that the site can be rendered on your local machine without Github Pages (this is how I generated the screenshot).

If you don't want to accept this PR, no problemo! But just in case you do, here it is!